### PR TITLE
issue19 2nd approach. add counter_absolute

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /usr/src/app
 
 RUN adduser --system --no-create-home --shell /usr/sbin/nologin mqtt_exporter
 COPY mqtt_exporter.py requirements-frozen.txt ./
+COPY utils ./utils
 RUN pip install --no-cache-dir -r requirements-frozen.txt
 
 USER mqtt_exporter

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -1,7 +1,7 @@
 # Tests with pytest
 
 make sure pytest is installed `pip install -r requirements-dev.txt` 
-run `pytest -s -o log_cli=true` from the repository root  
+run `pytest -s -o log_cli=true -o log_cli_level="DEBUG"` from the repository root  
 
 ## test_mqtt_explorer.py:test_update_metrics
 

--- a/tests/test_data/test_counter_absolute/conf.yaml
+++ b/tests/test_data/test_counter_absolute/conf.yaml
@@ -1,0 +1,22 @@
+
+# Logging
+logging:
+  # logfile:  'conf/mqttexperter.log'                                     # Optional default '' (stdout)
+  level:    'debug'                                 # Optional default 'info'
+
+timescale: 0
+
+# Metric definitions
+metrics:
+  - name: "fhem_rain_mm"
+    help: "443 Mhz Sensors, rain in mm/m2"
+    type: "counter_absolute"
+    topic: "fhem/+/+/rain_total"
+    label_configs:
+      - source_labels:  ['__msg_topic__']
+        target_label:   '__topic__'
+      - source_labels:  ["__msg_topic__"]
+        regex: "fhem/([^/]+).*"
+        target_label: "location"
+        replacement: '\1'
+        action: "replace"

--- a/tests/test_data/test_counter_absolute/mqtt_msg.csv
+++ b/tests/test_data/test_counter_absolute/mqtt_msg.csv
@@ -1,0 +1,13 @@
+in_topic;in_payload;out_name;out_labels;out_value;delay;assert
+fhem/Garten/rainmeter01/rain_total;4.8;fhem_rain_mm;{"location":"Garten","topic": "fhem/Garten/rainmeter01/rain_total"};4.8;4;True
+fhem/Garten/rainmeter01/rain_total;11.1;fhem_rain_mm;{"location":"Garten","topic": "fhem/Garten/rainmeter01/rain_total"};11.1;3;True
+fhem/Garten/rainmeter01/rain_total;110;fhem_rain_mm;{"location":"Garten","topic": "fhem/Garten/rainmeter01/rain_total"};110;5;True
+fhem/Garten/rainmeter01/rain_total;134.8;fhem_rain_mm;{"location":"Garten","topic": "fhem/Garten/rainmeter01/rain_total"};134.8;4;True
+fhem/Garten/rainmeter01/rain_total;211.1;fhem_rain_mm;{"location":"Garten","topic": "fhem/Garten/rainmeter01/rain_total"};211.1;3;True
+fhem/Garten/rainmeter01/rain_total;155.9;fhem_rain_mm;{"location":"Garten","topic": "fhem/Garten/rainmeter01/rain_total"};155.9;5;True
+fhem/Garten/rainmeter01/rain_total;2134.8;fhem_rain_mm;{"location":"Garten","topic": "fhem/Garten/rainmeter01/rain_total"};2134.8;4;True
+fhem/Garten/rainmeter01/rain_total;11.1;fhem_rain_mm;{"location":"Garten","topic": "fhem/Garten/rainmeter01/rain_total"};11.1;3;True
+fhem/Garten/rainmeter01/rain_total;155.9;fhem_rain_mm;{"location":"Garten","topic": "fhem/Garten/rainmeter01/rain_total"};155.9;5;True
+fhem/Garten/rainmeter01/rain_total;23134.8;fhem_rain_mm;{"location":"Garten","topic": "fhem/Garten/rainmeter01/rain_total"};23134.8;4;True
+fhem/Garten/rainmeter01/rain_total;1233123.123123123123;fhem_rain_mm;{"location":"Garten","topic": "fhem/Garten/rainmeter01/rain_total"};1233123.123123123123;3;True
+fhem/Garten/rainmeter01/rain_total;1233123.123123123124;fhem_rain_mm;{"location":"Garten","topic": "fhem/Garten/rainmeter01/rain_total"};1233123.123123123124;5;True

--- a/tests/test_prometheus_additions.py
+++ b/tests/test_prometheus_additions.py
@@ -1,0 +1,72 @@
+"""
+Pytest for prometheus client enhancements
+"""
+import os
+import logging
+import time
+import pytest
+from utils.prometheus_additions import CounterAbsolute
+import prometheus_client as prometheus
+
+logging.basicConfig(level=logging.DEBUG)
+
+TMP_DIR=os.path.join(
+    os.path.dirname(__file__),
+    'tmp_data'
+)
+DATA_DIR=os.path.join(
+    os.path.dirname(__file__),
+    'test_data'
+)
+
+@pytest.fixture(scope="class")
+def get_registry():
+    yield prometheus.REGISTRY
+    # reset prometheus registry between tests
+    collectors = list(prometheus.REGISTRY._collector_to_names.keys())
+    for collector in collectors:
+        prometheus.REGISTRY.unregister(collector)
+
+old_creation_time = 0.0
+
+class TestCounterWithReset:
+    a_counter_absolute = CounterAbsolute('Absolute_Counter', 'Test metric' )
+    old_creation_time = 0.0
+    param_test_data_sets = [
+        (10, False),
+        (10, True),
+        (11, True),
+        (110, True),
+        (110, True),
+        (210, True),
+        (310.7, True),
+        (110, False),
+        (210, True),
+        (310.7, True),
+    ]
+
+    @pytest.mark.parametrize("value, same_creation_time", param_test_data_sets)
+    def test_counter_absolute(self, request, get_registry, value, same_creation_time):
+        global old_creation_time
+        self.a_counter_absolute.set(value)
+        creation_time = self.a_counter_absolute._created
+        logging.info(f"Creation time: {creation_time:e}")
+        registry = get_registry
+        registry.collect()
+        prometheus.write_to_textfile(os.path.join(TMP_DIR, f"absolute_counter_{request.node.callspec.id}_{value:05}.txt"), prometheus.REGISTRY)
+
+        assert self.a_counter_absolute._value.get() == value
+        assert (creation_time == old_creation_time ) == same_creation_time
+        old_creation_time = creation_time
+        time.sleep(0.005)
+
+
+class TestCounterRestForbidden:
+    a_counter_absolute = CounterAbsolute('Strict_Absolute_Counter', "This Counters doesn't allow reset")
+
+    def test_counter_reset(self):
+        val_first = 0.3324234
+        val_second = 0.3324233
+        self.a_counter_absolute.set(val_first, fail_on_decrease=True)
+        with pytest.raises(ValueError, match=rf"Counter must increase {val_second} lower {val_first}"):
+            self.a_counter_absolute.set(val_second, fail_on_decrease=True)

--- a/utils/prometheus_additions.py
+++ b/utils/prometheus_additions.py
@@ -1,0 +1,40 @@
+"""
+Additions and Enhancements to the prometheus_client package
+"""
+
+import prometheus_client as prometheus
+
+class CounterAbsolute(prometheus.Counter):
+    """
+    CounterAbsolute allows to set the Counter by an absolute value like Gauge, but data is 
+    handled properly if counter resets or over flows.
+    CounterAbsolute is typically used if values need to by proxied from another source e.g. 
+    a network counter, SMTP or MQTT Data which return increasing but absolute numbers 
+    instead of a diff.
+
+    As counter must not decrease setting CounterAbsolute to a lower value is handled as follows:
+    A counter overflow or a reset is assumed and the create timestamp gets reset and internally 
+    a new Value object created.
+
+    An example for a CounterAbsolute:
+        from prometheus_client import Counter
+        c = CounterAbsolute('my_failures_total', 'Description of counter')
+        c.set(1123.63213)  # set to a absoluter value, if low than last value Counter gets reset.
+
+    """
+    _type = 'counter'
+
+
+    def set(self, value, fail_on_decrease=False):
+        """Increment counter to the given amount."""
+        self._raise_if_not_observable()
+        if value < 0:
+            raise ValueError('Counters can be a positive number only.')
+        if value >= self._value.get():
+            self._value.set(float(value))
+        else:
+            if fail_on_decrease:
+                raise ValueError(f"Counter must increase {value} lower {self._value.get()}")
+            else:
+                self._metric_init()
+                self._value.set(float(value))

--- a/utils/prometheus_additions.py
+++ b/utils/prometheus_additions.py
@@ -1,5 +1,5 @@
 """
-Additions and Enhancements to the prometheus_client package
+Additions and enhancements to the prometheus_client package
 """
 
 import prometheus_client as prometheus
@@ -9,17 +9,17 @@ class CounterAbsolute(prometheus.Counter):
     CounterAbsolute allows to set the Counter by an absolute value like Gauge, but data is 
     handled properly if counter resets or over flows.
     CounterAbsolute is typically used if values need to by proxied from another source e.g. 
-    a network counter, SMTP or MQTT Data which return increasing but absolute numbers 
+    a network counter, SMTP or MQTT data which return increasing but absolute numbers 
     instead of a diff.
 
-    As counter must not decrease setting CounterAbsolute to a lower value is handled as follows:
+    As Counter must not decrease, setting CounterAbsolute to a lower value is handled as follows:
     A counter overflow or a reset is assumed and the create timestamp gets reset and internally 
     a new Value object created.
 
     An example for a CounterAbsolute:
         from prometheus_client import Counter
         c = CounterAbsolute('my_failures_total', 'Description of counter')
-        c.set(1123.63213)  # set to a absoluter value, if low than last value Counter gets reset.
+        c.set(1123.63213)  # set to a absoluter value, if lower than last value Counter gets reset.
 
     """
     _type = 'counter'

--- a/utils/prometheus_additions.py
+++ b/utils/prometheus_additions.py
@@ -19,7 +19,7 @@ class CounterAbsolute(prometheus.Counter):
     An example for a CounterAbsolute:
         from prometheus_client import Counter
         c = CounterAbsolute('my_failures_total', 'Description of counter')
-        c.set(1123.63213)  # set to a absoluter value, if lower than last value Counter gets reset.
+        c.set(1123.63213)  # Set to an absolute value. If lower than last value, Counter gets reset.
 
     """
     _type = 'counter'


### PR DESCRIPTION
Have not changed the logic how to process for existing metrics including counter as with my first approache, but introduced another type "counter_absolute" that expect new absolute values instead of increments. If absolute value is lower than the last one and counter overflow or reset is expected and createtime time gets refreshed. This ensures promQL queries will work correctly.

It also includes refactoring and removes the cascaded type dependent function calling and the data saved at runtime. ${Type}Wrapper classes creating the metrics in the same manner as before. (May be this change should had happen in a separate PR)