### PR TITLE
Add expiration to remove stale metrics

### DIFF
--- a/exampleconf/metric_example.yaml
+++ b/exampleconf/metric_example.yaml
@@ -3,6 +3,7 @@ metrics:
   - name:     'mqtt_example'                        # Required(unique, if multiple, only last entry is kept)
     help:     'MQTT example gauge'                  # Required
     type:     'gauge'                               # Required ('gauge', 'counter', 'summary' or 'histogram')
+    expires:  60                                    # Optional time in seconds after last update to remove metric
     #parameters:                                    # Optional parameters for certain metrics
     #   buckets:                                    # Optional (Passed as 'buckets' argument to Histogram)
     #     - .1

--- a/mqtt_exporter.py
+++ b/mqtt_exporter.py
@@ -312,16 +312,19 @@ def _update_metrics(metrics, msg):
 
         if metric.get('expires'):
             if metric.get('expiration_timer'):
-                metric['expiration_timer'].cancel()
+                metric.get('expiration_timer').cancel()
+                logging.debug(f"_update_metric Canceled existing timer for {metric.get('name')}")
 
-            metric['expiration_timer'] = threading.Timer(metric.get('expires'), _remove_metric, args=(metric, derived_metric))
+            metric['expiration_timer'] = threading.Timer(metric.get('expires'), _clear_metric, args=(metric, derived_metric))
             metric['expiration_timer'].start()
+            logging.debug(f"_update_metric Set a {metric.get('expires')} second expiration timer for {metric.get('name')}")
 
 
-def _remove_metric(metric, derived_metric):
+def _clear_metric(metric, derived_metric):
     with METRICS_LOCK:
         metric['prometheus_metric']['parent'].clear()
         derived_metric['prometheus_metric']['parent'].clear()
+        logging.debug(f"_clear_metric cleared metric {metric.get('name')}")
 
 
 # noinspection PyUnusedLocal
@@ -474,10 +477,6 @@ class CounterWrapper():
         child.inc(value)
         return child
 
-class HistogramWrapper():
-    """
-    Wrapper to provide generic interface to Summary metric
-    """
 
 class CounterAbsoluteWrapper():
     """

--- a/mqtt_exporter.py
+++ b/mqtt_exporter.py
@@ -17,6 +17,7 @@ import prometheus_client as prometheus
 from yamlreader import yaml_load
 import utils.prometheus_additions
 import version
+import threading
 
 VERSION = version.__version__
 SUFFIXES_PER_TYPE = {
@@ -27,6 +28,7 @@ SUFFIXES_PER_TYPE = {
     "histogram": ['sum', 'count', 'bucket'],
     "enum": [],
 }
+METRICS_LOCK = threading.Semaphore()
 
 
 def _read_config(config_path):
@@ -308,16 +310,30 @@ def _update_metrics(metrics, msg):
         _export_to_prometheus(
             derived_metric['name'], derived_metric, derived_labels)
 
+        if metric.get('expires'):
+            if metric.get('expiration_timer'):
+                metric['expiration_timer'].cancel()
+
+            metric['expiration_timer'] = threading.Timer(metric.get('expires'), _remove_metric, args=(metric, derived_metric))
+            metric['expiration_timer'].start()
+
+
+def _remove_metric(metric, derived_metric):
+    with METRICS_LOCK:
+        metric['prometheus_metric']['parent'].clear()
+        derived_metric['prometheus_metric']['parent'].clear()
+
 
 # noinspection PyUnusedLocal
 def _on_message(client, userdata, msg):
-    """The callback for when a PUBLISH message is received from the server."""
-    logging.debug(
-        f'_on_message Msg received on topic: {msg.topic}, Value: {str(msg.payload)}')
+    with METRICS_LOCK:
+        """The callback for when a PUBLISH message is received from the server."""
+        logging.debug(
+            f'_on_message Msg received on topic: {msg.topic}, Value: {str(msg.payload)}')
 
-    for topic in userdata.keys():
-        if _topic_matches(topic, msg.topic):
-            _update_metrics(userdata[topic], msg)
+        for topic in userdata.keys():
+            if _topic_matches(topic, msg.topic):
+                _update_metrics(userdata[topic], msg)
 
 
 def _mqtt_init(mqtt_config, metrics):
@@ -358,7 +374,7 @@ def _export_to_prometheus(name, metric, labels):
     valid_types = metric_wrappers.keys()
     if metric['type'] not in valid_types:
         logging.error(
-            f"Metric type: {metric['type']}, is not a valid metric type. Must be one of: {valid_types} - ingnoring"
+            f"Metric type: {metric['type']}, is not a valid metric type. Must be one of: {valid_types} - ignoring"
         )
         return
 
@@ -430,6 +446,10 @@ class GaugeWrapper():
         self.metric = prometheus.Gauge(
             name, help_text, list(label_names)
         )
+
+    def clear(self):
+        self.metric.clear()
+
     def update(self, label_values, value):
         child = self.metric.labels(*label_values)
         child.set(value)
@@ -445,6 +465,9 @@ class CounterWrapper():
         self.metric = prometheus.Counter(
             name, help_text, list(label_names)
         )
+
+    def clear(self):
+        self.metric.clear()
 
     def update(self, label_values, value):
         child = self.metric.labels(*label_values)
@@ -466,6 +489,9 @@ class CounterAbsoluteWrapper():
             name, help_text, list(label_names)
         )
 
+    def clear(self):
+        self.metric.clear()
+
     def update(self, label_values, value):
         child = self.metric.labels(*label_values)
         child.set(value)
@@ -481,6 +507,9 @@ class SummaryWrapper():
         self.metric = prometheus.Summary(
             name, help_text, list(label_names)
         )
+
+    def clear(self):
+        self.metric.clear()
 
     def update(self, label_values, value):
         child = self.metric.labels(*label_values)
@@ -505,6 +534,9 @@ class HistogramWrapper():
             name, help_text, list(label_names), **params
         )
 
+    def clear(self):
+        self.metric.clear()
+
     def update(self, label_values, value):
         child = self.metric.labels(*label_values)
         child.observe(value)
@@ -520,6 +552,9 @@ class EnumWrapper():
         self.metric = prometheus.Enum(
             name, help_text, list(label_names), **params
         )
+
+    def clear(self):
+        self.metric.clear()
 
     def update(self, label_values, value):
         child = self.metric.labels(*label_values)


### PR DESCRIPTION
Resolves #59

This PR adds an optional `expires` parameter to the metrics configuration that takes an integer number of seconds, after which, without an update, the metric should be removed.

I'm looking for feedback at this point. I'm aware that I still need to add some debug logging statements and unit test coverage; I'll add those in once I get some agreement that the PR is heading in the generally correct direction.